### PR TITLE
Add conftest policies.

### DIFF
--- a/conftest/docker/docker.rego
+++ b/conftest/docker/docker.rego
@@ -1,0 +1,76 @@
+package docker
+
+import data.lib.docker
+
+suspicious_env_keys = [
+    "passwd",
+    "password",
+    "pass",
+    "secret",
+    "key",
+    "access",
+    "api_key",
+    "apikey",
+    "token",
+    "tkn"
+]
+
+forbidden_users_and_groups = [
+    "root",
+    "0"
+]
+
+preferred_images = [
+  "distroless"
+]
+
+# Suspicious environment variables
+warn_for_suspicious_env_keys[msg] {
+    input[i].Cmd == "env"
+    val := input[i].Value
+    contains(lower(val[_]), suspicious_env_keys[_])
+    msg := sprintf("Potential secret in ENV key found: %s", [val])
+}
+
+# Looking for ADD command instead using COPY command
+warn_when_add_command_is_used[msg] {
+    input[i].Cmd == "add"
+    val := concat(" ", input[i].Value)
+    msg := sprintf("Use COPY instead of ADD: %s", [val])
+}
+
+# sudo usage
+warn_on_sudo_use[msg] {
+    input[i].Cmd == "run"
+    val := concat(" ", input[i].Value)
+    contains(lower(val), "sudo")
+    msg := sprintf("Avoid using 'sudo' command: %s", [val])
+}
+
+# any preferred images
+warn_when_no_preferred_image[msg] {
+    docker.no_preferred_images_using_negation(preferred_images)
+    msg := "Could not find preferred image"
+}
+
+# no user defined
+warn_when_no_user[msg] {
+    not docker.any_user
+    msg := "Do not run as root, use USER instead"
+}
+
+# forbidden users
+warn_on_forbidden_user[msg] {
+    input[i].Cmd == "user"
+    val := split(input[i].Value[0], ":")
+    lower(val[0]) == forbidden_users_and_groups[_]
+    msg := sprintf("Forbidden user found: %s", [val[0]])
+}
+
+# forbidden groups
+warn_on_forbidden_group[msg] {
+    input[i].Cmd == "user"
+    val := split(input[i].Value[0], ":")
+    lower(val[1]) == forbidden_users_and_groups[_]
+    msg := sprintf("Forbidden group found: %s", [val[1]])
+}

--- a/conftest/docker/docker_test.rego
+++ b/conftest/docker/docker_test.rego
@@ -1,0 +1,165 @@
+package docker
+
+test_safe_env_var_should_pass {
+  count(warn_for_suspicious_env_keys) == 0 with input as
+  [
+    {
+      "Cmd": "env",
+      "Value": [
+          "something safe"
+      ]
+    }
+  ]
+}
+
+test_suspicious_env_var_should_not_pass {
+  count(warn_for_suspicious_env_keys) != 0 with input as
+  [
+    {
+      "Cmd": "env",
+      "Value": [
+          "passwd"
+      ]
+    }
+  ]
+}
+
+test_copy_command_should_pass {
+  count(warn_when_add_command_is_used) == 0 with input as
+  [
+    {
+      "Cmd": "copy",
+      "Value":
+      [
+        ""
+      ]
+    }
+  ]
+}
+
+test_add_command_should_not_pass {
+  count(warn_when_add_command_is_used) != 0 with input as
+  [
+    {
+      "Cmd": "add",
+      "Value":
+      [
+        ""
+      ]
+    }
+  ]
+}
+
+test_sudo_should_not_pass {
+  count(warn_on_sudo_use) != 0 with input as
+  [
+    {
+      "Cmd": "run",
+      "Value":
+      [
+        "sudo"
+      ]
+    }
+  ]
+}
+
+test_preferred_image_should_pass {
+  count(warn_when_no_preferred_image) == 0 with input as
+  [
+    {
+      "Cmd": "from",
+      "Value":
+      [
+        "distroless"
+      ]
+    }
+  ]
+}
+
+test_no_preferred_image_should_not_pass {
+  count(warn_when_no_preferred_image) != 0 with input as
+  [
+    {
+      "Cmd": "from",
+      "Value":
+      [
+        "alpine"
+      ]
+    }
+  ]
+}
+
+
+test_no_user_should_not_pass {
+  count(warn_when_no_user) != 0 with input as
+  [
+    {
+      "Cmd": "from",
+    }
+  ]
+}
+
+test_root_user_should_not_pass {
+  count(warn_on_forbidden_user) != 0 with input as
+  [
+    {
+      "Cmd": "user",
+      "Value":
+      [
+        "root"
+      ]
+    }
+  ]
+}
+
+test_okay_user_should_pass {
+  count(warn_on_forbidden_user) == 0 with input as
+  [
+    {
+      "Cmd": "user",
+      "Value":
+      [
+        "10:10"
+      ]
+    }
+  ]
+}
+
+test_user_zero_should_not_pass {
+  count(warn_on_forbidden_user) != 0 with input as
+  [
+    {
+      "Cmd": "user",
+      "Value":
+      [
+        "0:1"
+      ]
+    }
+  ]
+}
+
+test_okay_group_should_pass {
+  count(warn_on_forbidden_group) == 0 with input as
+  [
+    {
+      "Cmd": "user",
+      "Value":
+      [
+        "1:10"
+      ]
+    }
+  ]
+}
+
+test_forbidden_group_should_not_pass {
+  count(warn_on_forbidden_group) != 0 with input as
+  [
+    {
+      "Cmd": "user",
+      "Value":
+      [
+        "1:0"
+      ]
+    }
+  ]
+}

--- a/conftest/docker/lib/docker.rego
+++ b/conftest/docker/lib/docker.rego
@@ -1,0 +1,15 @@
+package lib.docker
+
+no_preferred_images_using_negation(preferred_images) {
+    not any_preferred_images(preferred_images)
+}
+
+any_preferred_images(preferred_images) {
+    input[i].Cmd == "from"
+    val := input[i].Value
+    contains(val[0], preferred_images[_])
+}
+
+any_user {
+    input[i].Cmd == "user"
+}

--- a/conftest/kubernetes/workloads/container.image.rego
+++ b/conftest/kubernetes/workloads/container.image.rego
@@ -1,0 +1,10 @@
+package kubernetes.container.image
+
+import data.lib.workload
+
+deny_latest_tag[msg] {
+  workload.is_workload
+	workload.containers[container]
+  contains(container.image, ":latest")
+	msg = sprintf("%s in the %s %s has an image, %s, using the latest tag", [container.name, workload.kind, workload.name, container.image])
+}

--- a/conftest/kubernetes/workloads/container.image.rego
+++ b/conftest/kubernetes/workloads/container.image.rego
@@ -2,9 +2,18 @@ package kubernetes.container.image
 
 import data.lib.workload
 
-deny_latest_tag[msg] {
-  workload.is_workload
-	workload.containers[container]
-  contains(container.image, ":latest")
-	msg = sprintf("%s in the %s %s has an image, %s, using the latest tag", [container.name, workload.kind, workload.name, container.image])
+known_sources := {"okay-source"}
+
+warn_latest_tag[msg] {
+  container := workload.containers[i]
+  image_prefix := split(container.image, ":")[1]
+  image_prefix == "latest"
+  msg = sprintf("Container: %s, in %s: %s, is using Image: %s, with tag latest", [container.name, workload.kind, workload.name, container.image])
+}
+
+warn_unknown_image_prefix[msg] {
+  container := workload.containers[i]
+  image_prefix := split(container.image, ":")[0]
+  not workload.has_field(known_sources, image_prefix)
+  msg = sprintf("Container: %s, in %s %s has an Image: %s, that comes from an unknown source", [container.name, workload.kind, container.image, workload.name])
 }

--- a/conftest/kubernetes/workloads/container.image_test.rego
+++ b/conftest/kubernetes/workloads/container.image_test.rego
@@ -1,0 +1,29 @@
+package kubernetes.container.image
+
+test_no_latest_tag_should_pass {
+  count(deny_latest_tag) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          image: ok-container-image
+`)
+}
+
+test_latest_tag_should_not_pass {
+  count(deny_latest_tag) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: container-name
+          image: flysas:latest
+`)
+}

--- a/conftest/kubernetes/workloads/container.image_test.rego
+++ b/conftest/kubernetes/workloads/container.image_test.rego
@@ -1,7 +1,7 @@
 package kubernetes.container.image
 
-test_no_latest_tag_should_pass {
-  count(deny_latest_tag) == 0 with input as yaml.unmarshal(`
+test_no_image_with_latest_tag_should_pass {
+  count(warn_latest_tag) == 0 with input as yaml.unmarshal(`
 kind: Deployment
 metadata:
   name: test
@@ -14,8 +14,8 @@ spec:
 `)
 }
 
-test_latest_tag_should_not_pass {
-  count(deny_latest_tag) != 0 with input as yaml.unmarshal(`
+test_one_latest_tag_should_not_pass {
+  count(warn_latest_tag) != 0 with input as yaml.unmarshal(`
 kind: Deployment
 metadata:
   name: test
@@ -25,5 +25,65 @@ spec:
       containers:
         - name: container-name
           image: flysas:latest
+`)
+}
+
+test_one_container_with_latest_tag_and_one_container_without_should_not_pass {
+  count(warn_latest_tag) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: container-name
+          image: flysas
+        - name: container-name
+          image: flysas:latest
+`)
+}
+
+test_one_image_from_trusted_registry_should_pass {
+  count(warn_unknown_image_prefix) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          image: okay-source
+`)
+}
+
+test_one_image_from_untrusted_registry_should_not_pass {
+  count(warn_unknown_image_prefix) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          image: not-okay-registry
+`)
+}
+
+test_several_images_from_untrusted_registries_should_not_pass {
+  count(warn_unknown_image_prefix) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          image: organisation-myApp
+        - name: second-container
+          image: not-okay-registry:some-version
 `)
 }

--- a/conftest/kubernetes/workloads/container.probe.rego
+++ b/conftest/kubernetes/workloads/container.probe.rego
@@ -1,0 +1,15 @@
+package kubernetes.container.probe
+
+import data.lib.workload
+
+warn_no_livenessprobe[msg] {
+  workload.containers[container]
+  not container.livenessProbe
+  msg := sprintf("%s %s has containers without livenessProbe", [workload.kind, workload.name])
+}
+
+warn_no_readinessprobe[msg] {
+  workload.containers[container]
+  not container.readinessProbe
+  msg := sprintf("%s %s has containers without readinessProbe", [workload.kind, workload.name])
+}

--- a/conftest/kubernetes/workloads/container.probe_test.rego
+++ b/conftest/kubernetes/workloads/container.probe_test.rego
@@ -1,0 +1,29 @@
+package kubernetes.container.probe
+
+import data.lib.workload
+
+test_livenessProbe_not_defined_should_warn {
+  count(warn_no_livenessprobe) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: container-name
+`)
+}
+
+test_readinessProbe_not_defined_should_warn {
+  count(warn_no_readinessprobe) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: container-name
+`)
+}

--- a/conftest/kubernetes/workloads/container.resources.rego
+++ b/conftest/kubernetes/workloads/container.resources.rego
@@ -1,0 +1,31 @@
+package kubernetes.resources
+
+import data.lib.workload
+
+deny_no_cpu_limit[msg] {
+  workload.is_workload
+	workload.containers[container]
+  not container.resources.limits.cpu
+  msg = sprintf("All containers in %s %s must set resources.limits.cpu", [workload.kind, workload.name])
+}
+
+deny_no_memory_limit[msg] {
+  workload.is_workload
+	workload.containers[container]
+  not container.resources.limits.memory
+  msg = sprintf("All containers in %s %s must set resources.limits.memory", [workload.kind, workload.name])
+}
+
+deny_no_cpu_request[msg] {
+  workload.is_workload
+	workload.containers[container]
+  not container.resources.requests.cpu
+  msg = sprintf("All containers in %s %s must set resources.requests.cpu", [workload.kind, workload.name])
+}
+
+deny_no_memory_request[msg] {
+  workload.is_workload
+	workload.containers[container]
+  not container.resources.requests.memory
+  msg = sprintf("All containers in %s %s must set resources.requests.memory", [workload.kind, workload.name])
+}

--- a/conftest/kubernetes/workloads/container.resources_test.rego
+++ b/conftest/kubernetes/workloads/container.resources_test.rego
@@ -1,0 +1,77 @@
+package kubernetes.resources
+
+test_cpu_limit_not_defined_should_not_pass {
+  count(deny_no_cpu_limit) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: container-name
+          resources:
+            requests:
+              cpu: 200m
+              memory: 1Gi
+            limits:
+              memory: 1Gi
+`)
+}
+
+test_memory_limit_not_defined_should_not_pass {
+  count(deny_no_memory_limit) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: container-name
+          resources:
+            requests:
+              cpu: 200m
+              memory: 1Gi
+            limits:
+              cpu: 200m
+`)
+}
+
+test_cpu_request_not_defined_should_not_pass {
+  count(deny_no_cpu_request) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: container-name
+          resources:
+            requests:
+              memory: 1Gi
+            limits:
+              cpu: 200m
+              memory: 1Gi
+`)
+}
+
+test_memory_request_not_defined_should_not_pass {
+  count(deny_no_memory_request) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: container-name
+          resources:
+            requests:
+              cpu: 200m
+            limits:
+              cpu: 200m
+              memory: 1Gi
+`)
+}

--- a/conftest/kubernetes/workloads/lib/permissions.rego
+++ b/conftest/kubernetes/workloads/lib/permissions.rego
@@ -1,0 +1,30 @@
+package lib.permissions
+
+import data.lib.workload
+
+check_pods(field) {
+  not input.spec.template.spec.securityContext[field]
+  c := input.spec.template.spec.securityContext
+  check_pod_id(c, field)
+}
+
+check_pod_id(c, field) {
+  not workload.has_field(c, field)
+}
+
+check_pod_id(c, field) {
+  c[field] < workload.lowest_allowed_id
+}
+
+check_containers(field) {
+  workload.containers[container]
+  check_container_id(container, field)
+}
+
+check_container_id(container, field) {
+  container.securityContext[field] < workload.lowest_allowed_id
+}
+
+check_container_id(container, field) {
+  not workload.has_field(container.securityContext, field)
+}

--- a/conftest/kubernetes/workloads/lib/workload.rego
+++ b/conftest/kubernetes/workloads/lib/workload.rego
@@ -3,8 +3,6 @@ package lib.workload
 kind := input.kind
 name := input.metadata.name
 
-lowest_allowed_id := 1000
-
 has_field(x, k) {
   _ = x[k]
 }
@@ -29,8 +27,4 @@ pod_containers(pod) = all_containers {
 containers[container] {
   all_containers = pod_containers(input.spec.template)
   container = all_containers[_]
-}
-
-split_image(image) = [image, "latest"] {
-  contains(image, ":latest")
 }

--- a/conftest/kubernetes/workloads/lib/workload.rego
+++ b/conftest/kubernetes/workloads/lib/workload.rego
@@ -1,0 +1,36 @@
+package lib.workload
+
+kind := input.kind
+name := input.metadata.name
+
+lowest_allowed_id := 1000
+
+has_field(x, k) {
+  _ = x[k]
+}
+
+is_workload {
+  kind = "Statefulset"
+}
+
+is_workload {
+  kind = "Deployment"
+}
+
+is_workload {
+  kind = "DaemonSet"
+}
+
+pod_containers(pod) = all_containers {
+  keys = {"containers", "initContainers"}
+  all_containers = [c | keys[k]; c = pod.spec[k][_]]
+}
+
+containers[container] {
+  all_containers = pod_containers(input.spec.template)
+  container = all_containers[_]
+}
+
+split_image(image) = [image, "latest"] {
+  contains(image, ":latest")
+}

--- a/conftest/kubernetes/workloads/metadata.rego
+++ b/conftest/kubernetes/workloads/metadata.rego
@@ -1,0 +1,6 @@
+package kubernetes.metadata
+
+deny[msg] {
+  not input.metadata.name
+  msg = "All manifests must include metadata.name"
+}

--- a/conftest/kubernetes/workloads/metadata_test.rego
+++ b/conftest/kubernetes/workloads/metadata_test.rego
@@ -1,0 +1,7 @@
+package kubernetes.metadata
+
+test_metadata_without_name_should_not_pass {
+    count(deny) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+`)
+}

--- a/conftest/kubernetes/workloads/network.rego
+++ b/conftest/kubernetes/workloads/network.rego
@@ -1,0 +1,33 @@
+package kubernetes.network
+
+import data.lib.workload
+
+pod := input.spec.template.spec
+
+# https://kubesec.io/basics/spec-hostaliases/
+deny_hostAliases[msg] {
+  workload.is_workload
+  pod.hostAliases
+  msg = sprintf("The %s %s is managing host aliases", [workload.kind, workload.name])
+}
+
+# https://kubesec.io/basics/spec-hostipc/
+deny_hostIPC[msg] {
+  workload.is_workload
+  pod.hostIPC
+  msg = sprintf("%s %s is sharing the host IPC namespace", [workload.kind, workload.name])
+}
+
+# https://kubesec.io/basics/spec-hostnetwork/
+deny_hostNetwork[msg] {
+  workload.is_workload
+  pod.hostNetwork
+  msg = sprintf("The %s %s is connected to the host network", [workload.kind, workload.name])
+}
+
+# https://kubesec.io/basics/spec-hostpid/
+deny_hostPID[msg] {
+  workload.is_workload
+  pod.hostPID
+  msg = sprintf("The %s %s is sharing the host PID", [workload.kind, workload.name])
+}

--- a/conftest/kubernetes/workloads/network_test.rego
+++ b/conftest/kubernetes/workloads/network_test.rego
@@ -1,0 +1,47 @@
+package kubernetes.network
+
+test_hostAliases_defined_should_not_pass {
+    count(deny_hostAliases) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      hostAliases:
+`)
+}
+
+test_hostIPC_defined_should_not_pass {
+    count(deny_hostIPC) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      hostIPC:
+`)
+}
+test_hostNetwork_defined_should_not_pass {
+    count(deny_hostNetwork) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      hostNetwork:
+`)
+}
+test_hostPID_defined_should_not_pass {
+    count(deny_hostPID) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      hostPID:
+`)
+}

--- a/conftest/kubernetes/workloads/pod.rego
+++ b/conftest/kubernetes/workloads/pod.rego
@@ -1,0 +1,6 @@
+package kubernetes.pod
+
+deny[msg] {
+  input.kind == "Pod"
+  msg = "Manifest kind: Pod not allowed"
+}

--- a/conftest/kubernetes/workloads/securityContext.allowPrivilegeEscalation.rego
+++ b/conftest/kubernetes/workloads/securityContext.allowPrivilegeEscalation.rego
@@ -1,0 +1,19 @@
+package kubernetes.securityContext.allowPrivilegeEscalation
+
+import data.lib.workload
+
+deny_allowPrivilegeEscalation[msg] {
+  workload.is_workload
+  allowPrivilegeEscalation
+  msg = sprintf("%s: %s, containers must have securityContext with allowPrivilegeEscalation: false", [input.kind, input.metadata.name])
+}
+
+allowPrivilegeEscalation {
+  workload.containers[container]
+  not workload.has_field(container.securityContext, "allowPrivilegeEscalation")
+}
+
+allowPrivilegeEscalation {
+  workload.containers[container]
+  container.securityContext.allowPrivilegeEscalation == true
+}

--- a/conftest/kubernetes/workloads/securityContext.allowPrivilegeEscalation_test.rego
+++ b/conftest/kubernetes/workloads/securityContext.allowPrivilegeEscalation_test.rego
@@ -1,0 +1,56 @@
+package kubernetes.securityContext.allowPrivilegeEscalation
+
+import data.lib.kubernetes
+
+test_privilegeEscalation_false_for_all_containers_should_pass {
+  count(deny_allowPrivilegeEscalation) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          securityContext:
+            allowPrivilegeEscalation: false
+        - name: privileged-container
+          securityContext:
+            allowPrivilegeEscalation: false
+`)
+}
+
+test_privilege_escalation_true_for_some_containers_should_not_pass {
+  count(deny_allowPrivilegeEscalation) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          securityContext:
+            allowPrivilegeEscalation: false
+        - name: privileged-container
+          securityContext:
+            allowPrivilegeEscalation: true
+`)
+}
+
+test_privilege_escalation_defined_on_some_containers_should_not_pass {
+  count(deny_allowPrivilegeEscalation) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          securityContext:
+            allowPrivilegeEscalation: false
+        - name: privileged-container
+          securityContext:
+`)
+}

--- a/conftest/kubernetes/workloads/securityContext.capabilities.rego
+++ b/conftest/kubernetes/workloads/securityContext.capabilities.rego
@@ -1,0 +1,14 @@
+package kubernetes.securityContext.capabilities
+
+import data.lib.workload
+
+deny_any_privileges[msg] {
+  workload.is_workload
+  workload.containers[container]
+  not drop_all_capabilities(container, "all")
+  msg = sprintf("%s: %s, containers must drop all capabilities", [workload.kind, workload.name])
+}
+
+drop_all_capabilities(container, capability) {
+  container.securityContext.capabilities.drop[_] == capability
+}

--- a/conftest/kubernetes/workloads/securityContext.capabilities_test.rego
+++ b/conftest/kubernetes/workloads/securityContext.capabilities_test.rego
@@ -1,0 +1,42 @@
+package kubernetes.securityContext.capabilities
+
+test_container_with_drop_all_capabilites_should_pass {
+  count(deny_any_privileges) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          securityContext:
+            capabilities:
+              drop:
+                - all
+        - name: privileged-container
+          securityContext:
+            capabilities:
+              drop:
+                - all
+`)
+}
+
+test_container_without_drop_all_capabilites_should_pass {
+  count(deny_any_privileges) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          securityContext:
+            capabilities:
+              drop:
+                - all
+        - name: privileged-container
+          securityContext:
+`)
+}

--- a/conftest/kubernetes/workloads/securityContext.fsGroup.rego
+++ b/conftest/kubernetes/workloads/securityContext.fsGroup.rego
@@ -1,0 +1,21 @@
+package kubernetes.securityContext.fsGroup
+
+import data.lib.workload
+
+min_allowed_fsGroup_id := 2
+
+deny_fsGroup[msg] {
+  workload.is_workload
+  fsGroup
+  msg = sprintf("%s: %s, pod must have a fsGroup defined with value above %v", [input.kind, input.metadata.name, min_allowed_fsGroup_id])
+}
+
+fsGroup {
+  c := input.spec.template.spec.securityContext
+  field := "fsGroup"
+  not workload.has_field(c, field)
+}
+
+fsGroup {
+  input.spec.template.spec.securityContext.fsGroup > min_allowed_fsGroup_id
+}

--- a/conftest/kubernetes/workloads/securityContext.fsGroup_test.rego
+++ b/conftest/kubernetes/workloads/securityContext.fsGroup_test.rego
@@ -1,0 +1,39 @@
+package kubernetes.securityContext.fsGroup
+
+test_fsGroup_with_low_id_should_pass {
+  count(deny_fsGroup) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        fsGroup: 1
+`)
+}
+
+test_fsGroup_with_too_high_id_should_not_pass {
+  count(deny_fsGroup) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        fsGroup: 4
+`)
+}
+
+test_fsGroup_not_defined_should_not_pass {
+  count(deny_fsGroup) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+`)
+}

--- a/conftest/kubernetes/workloads/securityContext.privileged.rego
+++ b/conftest/kubernetes/workloads/securityContext.privileged.rego
@@ -1,0 +1,10 @@
+package kubernetes.securityContext.privileged
+
+import data.lib.workload
+
+deny_privileged_container[msg] {
+  workload.is_workload
+  workload.containers[container]
+  container.securityContext.privileged == true
+  msg = sprintf("%s: %s, containers are not allowed to have securityContext with privileged: true %s", [workload.kind, workload.name, container.name])
+}

--- a/conftest/kubernetes/workloads/securityContext.privileged_test.rego
+++ b/conftest/kubernetes/workloads/securityContext.privileged_test.rego
@@ -1,0 +1,55 @@
+package kubernetes.securityContext.privileged
+
+import data.lib.workload
+
+test_privileged_false_for_all_containers_should_pass {
+  count(deny_privileged_container) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          securityContext:
+            privileged: false
+        - name: privileged-container
+          securityContext:
+            privileged: false
+`)
+}
+
+test_privileged_not_defined_for_any_container_should_pass {
+  count(deny_privileged_container) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          securityContext:
+        - name: privileged-container
+          securityContext:
+`)
+}
+
+test_privileged_true_for_some_containers_should_not_pass {
+  count(deny_privileged_container) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          securityContext:
+            privileged: false
+        - name: privileged-container
+          securityContext:
+            privileged: true
+`)
+}

--- a/conftest/kubernetes/workloads/securityContext.readOnlyRootFilesystem.rego
+++ b/conftest/kubernetes/workloads/securityContext.readOnlyRootFilesystem.rego
@@ -1,0 +1,10 @@
+package kubernetes.securityContext.readOnlyRootFilesystem
+
+import data.lib.workload
+
+deny_readOnlyRootFilesystem[msg] {
+  workload.is_workload
+  workload.containers[container]
+  not container.securityContext.readOnlyRootFilesystem
+  msg = sprintf("%s: %s, containers must have securityContext with readOnlyRootFilesystem: true", [workload.kind, workload.name])
+}

--- a/conftest/kubernetes/workloads/securityContext.readOnlyRootFilesystem_test.rego
+++ b/conftest/kubernetes/workloads/securityContext.readOnlyRootFilesystem_test.rego
@@ -1,0 +1,54 @@
+package kubernetes.securityContext.readOnlyRootFilesystem
+
+test_readOnlyRootFilesystem_true_for_all_containers_should_pass {
+  count(deny_readOnlyRootFilesystem) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          securityContext:
+            readOnlyRootFilesystem: true
+        - name: privileged-container
+          securityContext:
+            readOnlyRootFilesystem: true
+`)
+}
+
+test_readOnlyRootFilesystem_false_for_some_containers_should_not_pass {
+  count(deny_readOnlyRootFilesystem) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          securityContext:
+            readOnlyRootFilesystem: true
+        - name: privileged-container
+          securityContext:
+            readOnlyRootFilesystem: false
+`)
+}
+
+test_readOnlyRootFilesystem_not_defined_for_some_containers_should_not_pass {
+  count(deny_readOnlyRootFilesystem) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          securityContext:
+            readOnlyRootFilesystem: true
+        - name: privileged-container
+          securityContext:
+`)
+}

--- a/conftest/kubernetes/workloads/securityContext.runAsGroup.rego
+++ b/conftest/kubernetes/workloads/securityContext.runAsGroup.rego
@@ -1,0 +1,22 @@
+package kubernetes.securityContext.runAsGroup
+
+import data.lib.workload
+import data.lib.permissions
+
+min_allowed_id := 1000
+
+deny_runAsGroup[msg] {
+  workload.is_workload
+  field := "runAsGroup"
+  permissions.check_pods(field)
+  permissions.check_containers(field)
+  msg := sprintf("%s: %s, pod or all containers must have a runAsGroup defined with value above %v", [workload.kind, workload.name, min_allowed_id])
+}
+
+deny_runAsGroup[msg] {
+  workload.is_workload
+  workload.containers[container]
+  workload.has_field(container.securityContext, "runAsGroup")
+  container.securityContext.runAsGroup < 1000
+  msg := sprintf("%s: %s, pod or all containers must have a runAsGroup defined with value above %v", [workload.kind, workload.name, min_allowed_id])
+}

--- a/conftest/kubernetes/workloads/securityContext.runAsGroup_test.rego
+++ b/conftest/kubernetes/workloads/securityContext.runAsGroup_test.rego
@@ -1,0 +1,169 @@
+package kubernetes.securityContext.runAsGroup
+
+test_runAsGroup_defined_on_pod_and_all_containers_should_pass {
+  count(deny_runAsGroup) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsGroup: 1000
+      containers:
+        - name: first-container
+          securityContext:
+            runAsGroup: 1000
+        - name: privileged-container
+          securityContext:
+            runAsGroup: 1000
+`)
+}
+
+test_runAsGroup_defined_on_all_containers_should_pass {
+  count(deny_runAsGroup) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          securityContext:
+            runAsGroup: 1000
+        - name: privileged-container
+          securityContext:
+            runAsGroup: 1000
+`)
+}
+
+test_runAsGroup_defined_on_pod_and_some_containers_should_pass {
+  count(deny_runAsGroup) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsGroup: 1000
+      containers:
+        - name: first-container
+          securityContext:
+            runAsGroup: 1000
+        - name: privileged-container
+`)
+}
+
+test_runAsGroup_defined_on_pod_should_pass {
+  count(deny_runAsGroup) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsGroup: 1000
+      containers:
+        - name: first-container
+          securityContext:
+        - name: privileged-container
+          securityContext:
+`)
+}
+
+test_runAsGroup_defined_on_pod_with_low_id_and_all_containers_should_pass {
+  count(deny_runAsGroup) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsGroup: 999
+      containers:
+        - name: first-container
+          securityContext:
+            runAsGroup: 1000
+        - name: privileged-container
+          securityContext:
+            runAsGroup: 1000
+`)
+}
+
+test_runAsGroup_only_defined_on_some_container {
+  count(deny_runAsGroup) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+      containers:
+        - name: first-container
+          securityContext:
+        - name: privileged-container
+          securityContext:
+`)
+}
+
+test_runAsGroup_defined_on_some_container_should_not_pass {
+  count(deny_runAsGroup) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+      containers:
+        - name: first-container
+          securityContext:
+            runAsGroup: 1000
+        - name: privileged-container
+          securityContext:
+`)
+}
+
+test_runAsGroup_defined_on_all_containers_with_low_id_on_some_should_not_pass {
+  count(deny_runAsGroup) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+      containers:
+        - name: first-container
+          securityContext:
+            runAsGroup: 1000
+        - name: privileged-container
+          securityContext:
+            runAsGroup: 999
+`)
+}
+
+test_runAsGroup_defined_on_pod_and_all_containers_with_low_id_on_some_container_should_not_pass {
+  count(deny_runAsGroup) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsGroup: 1000
+      containers:
+        - name: first-container
+          securityContext:
+            runAsGroup: 1000
+        - name: privileged-container
+          securityContext:
+            runAsGroup: 999
+`)
+}

--- a/conftest/kubernetes/workloads/securityContext.runAsNonRoot.rego
+++ b/conftest/kubernetes/workloads/securityContext.runAsNonRoot.rego
@@ -1,0 +1,50 @@
+package kubernetes.securityContext.runAsNonRoot
+
+import data.lib.workload
+
+##########################################################################
+# can be removed when running aks v1.23
+#https://github.com/kubernetes/website/pull/30225
+#securityContext.runAsNonRoot
+deny_runAsNonRoot[msg] {
+  workload.is_workload
+  field := "runAsNonRoot"
+  check_pods(field)
+  check_containers(field)
+  msg := "cannot run as root"
+}
+
+deny_runAsNonRoot[msg] {
+  workload.is_workload
+  workload.containers[container]
+  workload.has_field(container.securityContext, "runAsNonRoot")
+  container.securityContext.runAsNonRoot != true
+  msg := "cannot run as root"
+}
+
+check_pods(field) {
+  not input.spec.template.spec.securityContext[field]
+  c := input.spec.template.spec.securityContext
+  check_pod_id(c, field)
+}
+
+check_pod_id(c, field) {
+  not workload.has_field(c, field)
+}
+
+check_pod_id(c, field) {
+  c[field] != true
+}
+
+check_containers(field) {
+  workload.containers[container]
+  check_container_id(container, field)
+}
+
+check_container_id(container, field) {
+  container.securityContext[field] != true
+}
+
+check_container_id(container, field) {
+  not workload.has_field(container.securityContext, field)
+}

--- a/conftest/kubernetes/workloads/securityContext.runAsNonRoot_test.rego
+++ b/conftest/kubernetes/workloads/securityContext.runAsNonRoot_test.rego
@@ -1,0 +1,119 @@
+package kubernetes.securityContext.runAsNonRoot
+
+test_runAsNonRoot_defined_everywhere {
+  count(deny_runAsNonRoot) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: first-container
+          securityContext:
+            runAsNonRoot: true
+        - name: privileged-container
+          securityContext:
+            runAsNonRoot: true
+`)
+}
+
+## kör på den här
+# test_runAsNonRoot_defined_on_pod_and_some_containers_should_pass {
+test_runAsRoot_not_defined_on_one_container {
+  count(deny_runAsNonRoot) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: first-container
+          securityContext:
+            runAsNonRoot: true
+        - name: privileged-container
+          securityContext:
+`)
+}
+
+test_runAsNonRoot_defined_on_pod_and_some_containers {
+  count(deny_runAsNonRoot) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: first-container
+          securityContext:
+            runAsNonRoot: true
+        - name: privileged-container
+          securityContext:
+`)
+}
+
+test_runAsNonRoot {
+  count(deny_runAsNonRoot) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: false
+      containers:
+        - name: first-container
+          securityContext:
+            runAsNonRoot: true
+        - name: privileged-container
+          securityContext:
+            runAsNonRoot: true
+`)
+}
+
+test_one_container_allows_runAsNonRoot {
+  count(deny_runAsNonRoot) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: first-container
+          securityContext:
+            runAsNonRoot: true
+        - name: privileged-container
+          securityContext:
+            runAsNonRoot: false
+`)
+}
+
+test_runAsNonRoot_not_defined_for_all_containers {
+  count(deny_runAsNonRoot) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+      containers:
+        - name: first-container
+          securityContext:
+            runAsNonRoot: true
+        - name: privileged-container
+          securityContext:
+`)
+}

--- a/conftest/kubernetes/workloads/securityContext.runAsUser.rego
+++ b/conftest/kubernetes/workloads/securityContext.runAsUser.rego
@@ -1,0 +1,22 @@
+package kubernetes.securityContext.runAsUser
+
+import data.lib.workload
+import data.lib.permissions
+
+min_allowed_id := 1000
+
+deny_runAsUser[msg] {
+  workload.is_workload
+  field := "runAsUser"
+  permissions.check_pods(field)
+  permissions.check_containers(field)
+  msg := sprintf("%s: %s, pod or all containers must have a runAsUser defined with value above %v", [workload.kind, workload.name, min_allowed_id])
+}
+
+deny_runAsUser[msg] {
+  workload.is_workload
+  workload.containers[container]
+  workload.has_field(container.securityContext, "runAsUser")
+  container.securityContext.runAsUser < min_allowed_id
+  msg := sprintf("%s: %s, pod or all containers must have a runAsUser defined with value above %v", [workload.kind, workload.name, min_allowed_id])
+}

--- a/conftest/kubernetes/workloads/securityContext.runAsUser_test.rego
+++ b/conftest/kubernetes/workloads/securityContext.runAsUser_test.rego
@@ -1,0 +1,169 @@
+package kubernetes.securityContext.runAsUser
+
+test_runAsUser_defined_on_pod_and_all_containers_should_pass {
+  count(deny_runAsUser) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsUser: 1000
+      containers:
+        - name: first-container
+          securityContext:
+            runAsUser: 1000
+        - name: privileged-container
+          securityContext:
+            runAsUser: 1000
+`)
+}
+
+test_runAsUser_defined_on_all_containers_should_pass {
+  count(deny_runAsUser) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+          securityContext:
+            runAsUser: 1000
+        - name: privileged-container
+          securityContext:
+            runAsUser: 1000
+`)
+}
+
+test_runAsUser_defined_on_pod_and_some_containers_should_pass {
+  count(deny_runAsUser) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsUser: 1000
+      containers:
+        - name: first-container
+          securityContext:
+            runAsUser: 1000
+        - name: privileged-container
+`)
+}
+
+test_runAsUser_defined_on_pod_should_pass {
+  count(deny_runAsUser) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsUser: 1000
+      containers:
+        - name: first-container
+          securityContext:
+        - name: privileged-container
+          securityContext:
+`)
+}
+
+test_runAsUser_defined_on_pod_with_low_id_and_all_containers_should_pass {
+  count(deny_runAsUser) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsUser: 999
+      containers:
+        - name: first-container
+          securityContext:
+            runAsUser: 1000
+        - name: privileged-container
+          securityContext:
+            runAsUser: 1000
+`)
+}
+
+test_runAsUser_only_defined_on_some_container {
+  count(deny_runAsUser) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+      containers:
+        - name: first-container
+          securityContext:
+        - name: privileged-container
+          securityContext:
+`)
+}
+
+test_runAsUser_defined_on_some_container_should_not_pass {
+  count(deny_runAsUser) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+      containers:
+        - name: first-container
+          securityContext:
+            runAsUser: 1000
+        - name: privileged-container
+          securityContext:
+`)
+}
+
+test_runAsUser_defined_on_all_containers_with_low_id_on_some_should_not_pass {
+  count(deny_runAsUser) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+      containers:
+        - name: first-container
+          securityContext:
+            runAsUser: 1000
+        - name: privileged-container
+          securityContext:
+            runAsUser: 999
+`)
+}
+
+test_runAsUser_defined_on_pod_and_all_containers_with_low_id_on_some_container_should_not_pass {
+  count(deny_runAsUser) != 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsUser: 1000
+      containers:
+        - name: first-container
+          securityContext:
+            runAsUser: 1000
+        - name: privileged-container
+          securityContext:
+            runAsUser: 999
+`)
+}

--- a/conftest/kubernetes/workloads/volumes.rego
+++ b/conftest/kubernetes/workloads/volumes.rego
@@ -1,0 +1,10 @@
+package kubernetes.volumes
+
+import data.lib.workload
+
+# https://kubesec.io/basics/spec-volumes-hostpath-path-var-run-docker-sock/
+deny[msg] {
+	volume = input.spec.template.spec.volumes[_]
+  contains(volume.hostPath.path, "/var/run/docker.sock")
+  msg = sprintf("%s %s is mounting the Docker socket", [workload.kind, workload.name])
+}

--- a/conftest/kubernetes/workloads/volumes_test.rego
+++ b/conftest/kubernetes/workloads/volumes_test.rego
@@ -1,0 +1,35 @@
+package kubernetes.volumes
+
+test_regular_volume_allowed {
+  count(deny) == 0 with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+      volumes:
+      - name: volume
+        hostPath:
+          path: /some/okay/volume
+`)
+}
+
+test_docker_sock_volume_not_allowed {
+  deny != set() with input as yaml.unmarshal(`
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+        - name: first-container
+      volumes:
+      - name: docker-sock-volume
+        hostPath:
+          path: /var/run/docker.sock
+`)
+}

--- a/conftest/policies.rego
+++ b/conftest/policies.rego
@@ -1,8 +1,0 @@
-package main
-
-deny[msg] {
-  input.kind == "Deployment"
-  not input.spec.template.spec.securityContext.runAsNonRoot
-
-  msg := "Containers must not run as root"
-}


### PR DESCRIPTION
För runAsUser, runAsGroup, och runAsNonRoot gäller detta:
[If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#securitycontext-v1-core)

Kolla gärna igenom testerna så att jag inte missat något.